### PR TITLE
Module load errors not being caught correctly during promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,8 @@ module.exports = function (source, inputSourceMap) {
         }
 
         callback(null, prefix + "\n" + source + postfix, inputSourceMap);
+    }).catch(function(error) {
+      callback(error);
     });
 
     /**


### PR DESCRIPTION
Need a `.catch()` on `mapBuilder` promise.
