### PR TITLE
Merge namespaces with objects attached to window as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,6 +209,8 @@ module.exports = function (source, inputSourceMap) {
                 rootVar,
                 '=__merge(',
                 rootVar,
+                '||window.',
+                rootVar,
                 '||{},',
                 JSON.stringify(globalVarTree[rootVar]),
                 ');'


### PR DESCRIPTION
My use case requires importing `google-closure-library/closure/goog/base.js` via `script-loader`, which causes `goog` to be injected into the global namespace. However, apparently global objects aren't visible inside an `eval()` without being prefixed with `.window`. This handles that possibility.
