### PR TITLE
Update Regex to match parent

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ module.exports = function (source, inputSourceMap) {
 
     function isParent(key, exportedVars) {
         var isParent = false;
-        var isParentRegExp = new RegExp('^' + key.replace('.', '\\.', 'g'));
+        var isParentRegExp = new RegExp('^' + key.split('.').join('\\.') + '\\.');
         for (var i=0; i < exportedVars.length; i++) {
             if (isParentRegExp.test(exportedVars[i])) return true;
         }


### PR DESCRIPTION
Existing code generates wrong regex. For example, 'goog.events.Listenable' will be /^goog\.events.Listenable/ that will match 'goog.events.ListenableType'. 

This change will generate /^goog\.events\.Listenable\./ instead to make sure it matches the child.