### PR TITLE
Check if a file is a file (and not a directory) before reading it

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,9 @@ module.exports = function (source, inputSourceMap) {
 
     this.cacheable && this.cacheable();
 
-    config = merge(defaultConfig, this.options[query.config || "closureLoader"], query);
+	config = merge(defaultConfig, {});
+    config = merge(this.options[query.config || "closureLoader"], config);
+	config = merge(query, config);
 
     mapBuilder(config.paths, config.watch).then(function(provideMap) {
         var provideRegExp = /goog\.provide *?\((['"])(.*?)\1\);?/,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "closure-loader",
-  "version": "0.1.14",
+  "name": "configurator-closure-loader",
+  "version": "0.1.15",
   "description": "Webpack loader for google closure library dependencies",
   "main": "index.js",
   "scripts": {
@@ -13,16 +13,17 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/eXaminator/closure-loader.git"
+    "url": "git://github.com/configurator/closure-loader.git"
   },
   "author": "Steven Weingärtner",
   "contributors": [
     "Michael van Engelshoven <michael@van-engelshoven.de>",
-    "Matthias Harmuth <mcpain83@gmail.com>"
+    "Matthias Harmuth <mcpain83@gmail.com>",
+	"Dor Kleiman <configurator@gmail.com>"
   ],
   "license": "MIT",
   "peerDependencies": {
-    "webpack": "^1.9.10"
+    "webpack": "^2.3.2"
   },
   "dependencies": {
     "bluebird": "^3.4.1",


### PR DESCRIPTION
This fixes a bug where the loader attempts to read directories if they're named `*.js`. We ran into this with some of our dependencies: `Chart.js` and `less.js`, both installed via bower.