### PR TITLE
Configurable file extension of dependency map loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ module.exports = {
             __dirname + '/src'
         ],
         es6mode: true,
-        watch: true
+        watch: true,
+        fileExt: '.js'
     }
 };
 ```
@@ -116,6 +117,8 @@ Here are the configuration options specific for this loader:
   changes in the mapped files. This is neccesary to be able to delete the internal map cache. But
   it also makes problems with CI sytstems and build scripts, because the watcher will prevent the
   process from beeing exited.
+- **fileExt** (string, default: '.js'): Files extension which will be searched for dependency resolving. 
+  Support [glob](https://github.com/isaacs/node-glob) pattern syntax.
 
 ## Examples
 In the hopes of clarifying the usage of the loader a bit I have provided a couple of examples which

--- a/dependencyMapBuilder.js
+++ b/dependencyMapBuilder.js
@@ -15,11 +15,12 @@ var _ = require('lodash'),
  *
  * @param {string[]} directories Directories to be processed
  * @param {boolean} watch Watch for changes is mapped files to invalidate cache
+ * @param {string} fileExt Searched file extensions
  * @returns {Promise}
  */
-module.exports = function (directories, watch) {
+module.exports = function (directories, watch, fileExt) {
     return Promise.map(directories, function(dir) {
-        return resolveAndCacheDirectory(dir, watch)
+        return resolveAndCacheDirectory(dir, watch, fileExt)
     }).then(function(results) {
         return _.assign.apply(_, results);
     })
@@ -51,9 +52,11 @@ function createWatchPromise(directory) {
  * in this directory and deletes the cached object.
  *
  * @param {string} directory
+ * @param {boolean} watch Watch for changes is mapped files to invalidate cache
+ * @param {string} fileExt Searched file extensions
  * @returns {Promise}
  */
-function resolveAndCacheDirectory(directory, watch) {
+function resolveAndCacheDirectory(directory, watch, fileExt) {
 
     if (cache[directory]) {
         return cache[directory];
@@ -61,7 +64,7 @@ function resolveAndCacheDirectory(directory, watch) {
 
     cache[directory] = (watch ? createWatchPromise(directory) : Promise.resolve())
         .then(function() {
-            return glob(path.join(directory, '/**/*.js'));
+            return glob(path.join(directory, '/**/*' + fileExt));
         })
         .map(function(filePath) {
             return findProvideCalls(filePath);

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var loaderUtils = require("loader-utils"),
     defaultConfig = config = {
         paths: [],
         es6mode: false,
-        watch: true
+        watch: true,
+        fileExt: '.js'
     },
     prefix, postfix;
 
@@ -24,7 +25,7 @@ module.exports = function (source, inputSourceMap) {
 
     config = merge({}, defaultConfig, this.options[query.config || "closureLoader"], query);
 
-    mapBuilder(config.paths, config.watch).then(function(provideMap) {
+    mapBuilder(config.paths, config.watch, config.fileExt).then(function(provideMap) {
         var provideRegExp = /goog\.provide *?\((['"])(.*?)\1\);?/,
             requireRegExp = /goog\.require *?\((['"])(.*?)\1\);?/,
             globalVarTree = {},


### PR DESCRIPTION
resolves #23 
* added default config.fileExt - `.js`
* added info to readme about configuration
* fixed missing doc `watch` in `dependencyMapBuilder.js:resolveAndCacheDirectory`