### PR TITLE
Insert newline before adding postfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ module.exports = function (source, inputSourceMap) {
      * @returns {string}
      */
     function createPostfix(exportVarTree, exportedVars, config) {
-        postfix = ';';
+        postfix = '\n;';
         Object.keys(exportVarTree).forEach(function (rootVar) {
             var jsonObj;
             enrichExport(exportVarTree[rootVar], rootVar);


### PR DESCRIPTION
Ran into an edge case where the postfix was being added in a line that started with `//` which led to weird errors. 
Adding a newline before the postfix ensures that the generated code will not run the risk of being commented.