### PR TITLE
don't mutate globals from module prefix code

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,9 +231,9 @@ module.exports = function (source, inputSourceMap) {
                 rootVar,
                 '=__merge(',
                 rootVar,
-                '||window.',
+                '||__merge({}, window.',
                 rootVar,
-                '||{},',
+                '),',
                 JSON.stringify(globalVarTree[rootVar]),
                 ');'
             ].join('');


### PR DESCRIPTION
Fixes #31. If the `rootVar` exists as a global on window, the module prefix code should clone that object into the local version of the namespace, but not mutate the global.