### PR TITLE
safer approach for creating local namespaces

### DIFF
--- a/export-path.js
+++ b/export-path.js
@@ -1,0 +1,24 @@
+/**
+* Ensure that a dotted path is defined on a namespace object. Will create
+* intermediate namespaces that are not defined as empty objects, and will
+* optionally set a value at the end of the path.
+*
+ * @param {Object} namespace
+ * @param {string} name
+ * @param {*=} value
+*/
+module.exports = function(namespace, name, value) {
+  var parts = name.split('.');
+  var target = namespace;
+
+  for (var i = 0; i < parts.length; i++) {
+    var part = parts[i];
+    if (i === parts.length - 1 && value !== undefined) {
+      target[part] = value;
+    } else if (target[part]) {
+      target = target[part];
+    } else {
+      target = target[part] = {};
+    }
+  }
+};

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = function (source, inputSourceMap) {
             .filter(removeNested)
             .map(buildVarTree(exportVarTree));
 
-        prefix = createPrefix(globalVarTree);
+        prefix = createPrefix(globalVarTree, globalVars);
         postfix = createPostfix(exportVarTree, exportedVars, config);
 
         if(inputSourceMap) {
@@ -116,13 +116,7 @@ module.exports = function (source, inputSourceMap) {
         path = loaderUtils.stringifyRequest(self, provideMap[key]);
         requireString = 'require(' + path + ').' + key;
 
-        // if the required module is a parent of a provided module, use deep-extend so that injected
-        // namespaces are not overwritten
-        if (isParent(key, exportedVars)) {
-          return source.replace(replaceRegex, key + '=__merge(' + requireString + ', (' + key + ' || {}));');
-        } else {
-          return source.replace(replaceRegex, key + '=' + requireString + ';');
-        }
+        return source.replace(replaceRegex, `__exportPath(__closureLoaderNamespace,'${key}',${requireString});`);
     }
 
     /**
@@ -220,26 +214,28 @@ module.exports = function (source, inputSourceMap) {
      * into a module that creates its own goog variables. That's why it has to be executed in eval.
      *
      * @param globalVarTree
+     * @param globalVars
      * @returns {string}
      */
-    function createPrefix(globalVarTree) {
-        var merge = "var __merge=require(" + loaderUtils.stringifyRequest(self, require.resolve('deep-extend')) + ");";
-        prefix = '';
-        Object.keys(globalVarTree).forEach(function (rootVar) {
-            prefix += [
-                'var ',
-                rootVar,
-                '=__merge(',
-                rootVar,
-                '||__merge({}, window.',
-                rootVar,
-                '),',
-                JSON.stringify(globalVarTree[rootVar]),
-                ');'
-            ].join('');
+    function createPrefix(globalVarTree, globalVars) {
+        let prefix = '';
+        prefix += `var __exportPath=require(${loaderUtils.stringifyRequest(self, require.resolve('./export-path.js'))});`;
+        prefix += 'var __closureLoaderNamespace = {};';
+        Object.keys(globalVarTree).forEach((rootVar) => {
+            prefix += `__closureLoaderNamespace.${rootVar} = (typeof ${rootVar} !== "undefined") ? ${rootVar} : window.${rootVar} || {};`;
         });
 
-        return merge + "eval('" +  prefix.replace(/'/g, "\\'") + "');";
+        let evalContent = '';
+        Object.keys(globalVarTree).forEach((rootVar) => {
+            evalContent += `var ${rootVar} = __closureLoaderNamespace.${rootVar};`;
+        });
+        evalContent = evalContent.replace(/'/g, "\\'");
+
+        prefix += `eval('${evalContent}');`;
+
+        prefix += `${JSON.stringify(globalVars)}.forEach(function(n){ __exportPath(__closureLoaderNamespace, n); });`;
+
+        return prefix;
     }
 
     /**


### PR DESCRIPTION
Hi! In a larger Closure codebase, I've encountered infinite recursion in the loader's module prefix code. It seems to be a problem whenever one of the objects being merged has any circular references, e.g:
```
$ node
> const __merge = require('deep-extend');
undefined
> const x = {};
undefined
> const y = {};
undefined
> x.y = y;
{}
> y.x = x;
{ y: { x: [Circular] } }
> __merge({}, x);
RangeError: Maximum call stack size exceeded
```

So in this branch I've entirely removed `node-deep-extend` from the loader's output, and instead take an approach similar to Closure's "[exportPath_](https://github.com/google/closure-library/blob/676e186b831c823d5dae95aa891854758d076b83/closure/goog/base.js#L144)". A local namespace object is created, then any global Closure variables are initialized on it – since it doesn't attempt to merge the global vars themselves, it avoids infinite recursion.

This has the side-effect of (partially) regressing #31 – the example in that ticket now outputs `[1, 2, 1, 2]`. It's again injecting things onto the global variable that shouldn't be there, but is no longer wiping out values that had been previously set. I couldn't think of a satisfying way to both avoid infinite recursion and keep that behavior, but I think it's probably fine since nothing is getting overwritten? Curious what you think!

The examples in the repo seem to still work 😃 