### PR TITLE
alternate approach for creating local namespaces

### DIFF
--- a/export-path.js
+++ b/export-path.js
@@ -1,0 +1,24 @@
+/**
+* Ensure that a dotted path is defined on a namespace object. Will create
+* intermediate namespaces that are not defined as empty objects, and will
+* optionally set a value at the end of the path.
+*
+ * @param {Object} namespace
+ * @param {string} name
+ * @param {*=} value
+*/
+module.exports = function(namespace, name, value) {
+  var parts = name.split('.');
+  var target = namespace;
+
+  for (var i = 0; i < parts.length; i++) {
+    var part = parts[i];
+    if (i === parts.length - 1 && value !== undefined) {
+      target[part] = value;
+    } else if (target[part]) {
+      target = target[part];
+    } else {
+      target = target[part] = {};
+    }
+  }
+};

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = function (source, inputSourceMap) {
             .filter(removeNested)
             .map(buildVarTree(exportVarTree));
 
-        prefix = createPrefix(globalVarTree);
+        prefix = createPrefix(globalVarTree, globalVars);
         postfix = createPostfix(exportVarTree, exportedVars, config);
 
         if(inputSourceMap) {
@@ -116,13 +116,7 @@ module.exports = function (source, inputSourceMap) {
         path = loaderUtils.stringifyRequest(self, provideMap[key]);
         requireString = 'require(' + path + ').' + key;
 
-        // if the required module is a parent of a provided module, use deep-extend so that injected
-        // namespaces are not overwritten
-        if (isParent(key, exportedVars)) {
-          return source.replace(replaceRegex, key + '=__merge(' + requireString + ', (' + key + ' || {}));');
-        } else {
-          return source.replace(replaceRegex, key + '=' + requireString + ';');
-        }
+        return source.replace(replaceRegex, `__exportPath(__closureLoaderNamespace,'${key}',${requireString});`);
     }
 
     /**
@@ -220,26 +214,28 @@ module.exports = function (source, inputSourceMap) {
      * into a module that creates its own goog variables. That's why it has to be executed in eval.
      *
      * @param globalVarTree
+     * @param globalVars
      * @returns {string}
      */
-    function createPrefix(globalVarTree) {
-        var merge = "var __merge=require(" + loaderUtils.stringifyRequest(self, require.resolve('deep-extend')) + ");";
-        prefix = '';
-        Object.keys(globalVarTree).forEach(function (rootVar) {
-            prefix += [
-                'var ',
-                rootVar,
-                '=__merge(',
-                rootVar,
-                '||__merge({}, window.',
-                rootVar,
-                '),',
-                JSON.stringify(globalVarTree[rootVar]),
-                ');'
-            ].join('');
+    function createPrefix(globalVarTree, globalVars) {
+        let prefix = '';
+        prefix += `var __exportPath=require(${loaderUtils.stringifyRequest(self, require.resolve('./export-path.js'))});`;
+        prefix += 'var __closureLoaderNamespace = {};';
+        Object.keys(globalVarTree).forEach((rootVar) => {
+            prefix += `__closureLoaderNamespace.${rootVar} = (typeof ${rootVar} !== "undefined") ? ${rootVar} : window.${rootVar} || {};`;
         });
 
-        return merge + "eval('" +  prefix.replace(/'/g, "\\'") + "');";
+        let evalContent = '';
+        Object.keys(globalVarTree).forEach((rootVar) => {
+            evalContent += `var ${rootVar} = __closureLoaderNamespace.${rootVar};`;
+        });
+        evalContent = evalContent.replace(/'/g, "\\'");
+
+        prefix += `eval('${evalContent}');`;
+
+        prefix += `${JSON.stringify(globalVars)}.forEach(function(n){ __exportPath(__closureLoaderNamespace, n); });`;
+
+        return prefix;
     }
 
     /**


### PR DESCRIPTION
Using a deep-merge can cause stack overflows when required objects have
recursive references. This is made safe by adding only the paths that
are explicitly provided / required by the source file.