### PR TITLE
Do not look for goog.provide/require in comments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -205,7 +205,10 @@ function createPrefix(loaderContext, globalVarTree, globalVars, useEval) {
 module.exports = function loader(originalSource, inputSourceMap) {
     const self = this;
     const callback = this.async();
-    let source = originalSource;
+    let source = originalSource
+        //.replace(/\/\/.*/g, '') // remove line comments (somehow this bugs)
+        .replace(/\/\*[^]*?\*\//g, '/* stripped comment */'); // block comments
+
     let globalVars = [];
     let exportedVars = [];
 


### PR DESCRIPTION
This is a workaround for the issue #16  "Incorrectly finds `goog.require` and `goog.provide` statements in comments"